### PR TITLE
Check derivative exists before updating x0 on it

### DIFF
--- a/lib/helpers/derivative.js
+++ b/lib/helpers/derivative.js
@@ -41,7 +41,9 @@ module.exports = function (chart) {
       d.derivative.$$mouseListener = function (x0) {
         // update initial value to be the position of the mouse
         // scope's x0 will be updated on the next call to `derivative(self)`
-        d.derivative.x0 = x0
+        if (d.derivative) {
+          d.derivative.x0 = x0
+        }
         // trigger update (selection = self)
         derivative(self)
       }


### PR DESCRIPTION
I ran into a bug where this method would throw an error after I deleted the `derivative` property from a datum. I added a check to ensure the property exists before setting `x0`. Is this the way you want this done, or would you prefer to unregister the event handler altogether?