### PR TITLE
area closed wieth graphType: "polyline" fix

### DIFF
--- a/lib/samplers/builtIn.js
+++ b/lib/samplers/builtIn.js
@@ -57,7 +57,7 @@ function split (chart, meta, data) {
   var yMin = domain[0]
   var yMax = domain[1]
 
-  if (data[0]) {
+  if (data[0] && data[1]) {
     st.push(data[0])
     deltaX = data[1][0] - data[0][0]
     oldSign = utils.sgn(data[1][1] - data[0][1])


### PR DESCRIPTION
ploting with optons:
closed: true,
range:[0,2],
graphType: "polyline"
causes an error when, max plot range is under xAxes range (move plot left).