### PR TITLE
Add MIT license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2015 Mauricio Poppe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Resolves #107. I see the [License](https://github.com/mauriciopoppe/function-plot#license) section of the readme, but as mentioned in the attached issue, I don't believe the terms of the MIT license apply if the terms themselves are not written anywhere.

Also, as [the Free Software Foundation notes](https://www.gnu.org/licenses/license-list.html#Expat "Various Licenses and Comments about Them - GNU Project"), just using the phrase "the MIT license" is ambiguous, because MIT has used many licenses for their software, and there are two MIT licenses in common use today: the Expat license and the X11 license.

I chose 2015 as the copyright year in this license file to [match the readme](https://github.com/mauriciopoppe/function-plot#license), but I'd be happy to update it to 2020 or another appropriate year or range.