### PR TITLE
Add window check to enable server-side rendering

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -8,7 +8,9 @@
 // src: http://stackoverflow.com/questions/6481612/queryselector-search-immediate-children
 
 /*eslint-disable */
-;(function (doc, proto) {
+
+if (typeof window !== 'undefined')
+(function (doc, proto) {
   try { // check if browser supports :scope natively
     doc.querySelector(':scope body')
   } catch (err) { // polyfill native methods if it doesn't


### PR DESCRIPTION
Using this library in a server-side generated Gatsby app causes the static HTML build to fail because `window` is not defined in the polyfills. This PR adds a line to only install polyfills when in a browser context (i.e. `window` is defined)