### PR TITLE
Type `FunctionPlotOptions.target` missing `HTMLElement` and Github Actions build workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,33 @@
+name: Build and Test
+
+on:
+  push:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3.1.1
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Test
+        run: npm run test
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to Chromatic
+        if: github.event_name != "pull_request"
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+
+      - name: Run Fossa and upload data
+        uses: fossa-contrib/fossa-action@v1
+        with:
+          fossa-api-key: abcdefghijklmnopqrstuvwxyz

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
         run: npm run build
 
       - name: Publish to Chromatic
-        if: github.event_name != "pull_request"
+        if: github.event_name != 'pull_request'
         uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,7 @@ export class Chart extends EventEmitter.EventEmitter {
   }
 
   private getDraggableNode() {
-    return d3Select(this.options.target).select('.zoom-and-drag').node()
+    return d3Select(this.options.target as any).select('.zoom-and-drag').node()
   }
 
   /**
@@ -271,7 +271,7 @@ export class Chart extends EventEmitter.EventEmitter {
   }
 
   drawGraphWrapper () {
-    const root = this.root = d3Select(this.options.target)
+    const root = this.root = d3Select(this.options.target as any)
       .selectAll('svg')
       .data([this.options])
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -278,7 +278,7 @@ export interface FunctionPlotOptions {
   /**
    * A css selector or DOM node of the parent element that will contain the graph
    */
-  target: string
+  target: string | HTMLElement
 
   /**
    * The chart title


### PR DESCRIPTION
Hi.
While doing some small project (a graph rendering plugin for obsidian.md, also im kinda new to ts) i encountered a missing type for the `target` property in FunctionPlotOptions. It says that just `string` is allowed, while when testing in codesandbox, just specifying an element (`HTMLElement`) clearly works too. Currently you have to do some kind of type-casting and that just doesnt feel as smooth as it should. Great library though!