### PR TITLE
working workflow, individually check for the existence of secrets

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    env:
+      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -25,12 +29,13 @@ jobs:
         run: npm run build
 
       - name: Publish to Chromatic
-        if: github.event_name != 'pull_request'
+        if: env.CHROMATIC_PROJECT_TOKEN != ''
         uses: chromaui/action@v1
         with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          projectToken: ${{ env.CHROMATIC_PROJECT_TOKEN }}
 
       - name: Run Fossa and upload data
+        if: env.FOSSA_API_KEY != ''
         uses: fossa-contrib/fossa-action@v1
         with:
-          fossa-api-key: ${{ secrets.FOSSA_API_KEY }}
+          fossa-api-key: ${{ env.FOSSA_API_KEY }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,15 +8,13 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-    
+
     env:
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
 
       - uses: actions/setup-node@v3.1.1
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    
     env:
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
       FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}


### PR DESCRIPTION
Hi it's me again. I modified the workflow to check for the existence of the required secrets (`CHROMATIC_PROJECT_TOKEN` and `FOSSA_API_KEY`), so that these steps don't run when no token is configured. This way it makes much more sense than just disabling the workflow for pull requests, since then forked repos would have had to add their tokens or have the workflow immediately fail.
This is meant to be a drop-in replacement, since the secrets are already configured. Basically just 'merge/rebase' and that's it.

PS: The solution to testing for secrets is a bit hacky, github actions doesn't have anything nicer.
PS2: The `fetch-depth: 0` can be removed, we don't need the entire repo (currently it takes a whole minute to download the repo). We only need the latest code (commit). 