### PR TITLE
fix to use the proper scale for polyline & closed graphs

### DIFF
--- a/src/graph-types/polyline.ts
+++ b/src/graph-types/polyline.ts
@@ -43,7 +43,7 @@ export default function polyline(chart: Chart) {
         .y(y)
       const area = d3Area()
         .x(function (d) {
-          return chart.meta.yScale(d[0])
+          return chart.meta.xScale(d[0])
         })
         .y0(chart.meta.yScale(0))
         .y1(y)


### PR DESCRIPTION
I noticed that you get the wrong graph when using graphType: "polyline" and closed: true together, and it turns out the wrong axis's scaling function was being used

I've remade the pull request to not include unnecessary commits that were in the last request