### PR TITLE
Install events library from npm, vite can build apps that use functionPlot

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Thanks to [@liuyao12](https://github.com/liuyao12) for the initial version of th
 npm install function-plot
 ```
 
-## Examples
+## Usage
 
 ```javascript
 import functionPlot from 'function-plot'

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "d3-selection": "^3.0.0",
         "d3-shape": "^3.1.0",
         "d3-zoom": "^3.0.0",
+        "events": "^3.3.0",
         "interval-arithmetic-eval": "^0.5.1"
       },
       "devDependencies": {
@@ -9812,7 +9813,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.x"
       }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "d3-selection": "^3.0.0",
     "d3-shape": "^3.1.0",
     "d3-zoom": "^3.0.0",
+    "events": "^3.3.0",
     "interval-arithmetic-eval": "^0.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Bundlers like vite does not automatically polyfill node modules, functionPlot uses the events library from npm and relies on the bundler to bundle it when needed.

The solution is to install events from npm, it has the same API and it tells the bundler that it should install it when functionPlot is used.

Should address #250 