### PR TITLE
Minimize dependency on Chart in the evaluators module

### DIFF
--- a/src/chart.ts
+++ b/src/chart.ts
@@ -1,6 +1,6 @@
 import { line as d3Line, Line } from 'd3-shape'
 import { format as d3Format } from 'd3-format'
-import { scaleLinear as d3ScaleLinear, scaleLog as d3ScaleLog, ScaleLinear, ScaleLogarithmic } from 'd3-scale'
+import { scaleLinear as d3ScaleLinear, scaleLog as d3ScaleLog } from 'd3-scale'
 import { axisLeft as d3AxisLeft, axisBottom as d3AxisBottom, Axis } from 'd3-axis'
 import { zoom as d3Zoom } from 'd3-zoom'
 // @ts-ignore
@@ -8,7 +8,7 @@ import { select as d3Select, pointer as d3Pointer } from 'd3-selection'
 import { interpolateRound as d3InterpolateRound } from 'd3-interpolate'
 import EventEmitter from 'events'
 
-import { FunctionPlotOptions, FunctionPlotDatum } from './types'
+import { FunctionPlotOptions, FunctionPlotDatum, FunctionPlotScale } from './types'
 
 import annotations from './helpers/annotations'
 import mousetip from './tip'
@@ -39,8 +39,8 @@ export interface ChartMeta {
    */
   height?: number
   zoomBehavior?: any
-  xScale?: ScaleLinear<number, number> | ScaleLogarithmic<number, number>
-  yScale?: ScaleLinear<number, number> | ScaleLogarithmic<number, number>
+  xScale?: FunctionPlotScale
+  yScale?: FunctionPlotScale
   xAxis?: Axis<any>
   yAxis?: Axis<any>
   xDomain?: number[]

--- a/src/helpers/secant.ts
+++ b/src/helpers/secant.ts
@@ -1,13 +1,13 @@
-import {select as d3Select, Selection} from 'd3-selection'
+import { select as d3Select, Selection } from 'd3-selection'
 
 import { builtIn as builtInEvaluator } from './eval'
 import datumDefaults from '../datum-defaults'
 import { polyline } from '../graph-types/'
 
-import { Chart } from "../index";
+import { Chart } from '../index'
 import { FunctionPlotDatumScope, FunctionPlotDatum, FunctionPlotDatumSecant } from '../types'
 
-export default function secant (chart: Chart) {
+export default function secant(chart: Chart) {
   const secantDefaults = datumDefaults({
     isHelper: true,
     skipTip: true,
@@ -16,11 +16,11 @@ export default function secant (chart: Chart) {
     graphType: 'polyline'
   })
 
-  function computeSlope (scope: FunctionPlotDatumScope) {
+  function computeSlope(scope: FunctionPlotDatumScope) {
     scope.m = (scope.y1 - scope.y0) / (scope.x1 - scope.x0)
   }
 
-  function updateLine (d: FunctionPlotDatum, secant: FunctionPlotDatumSecant) {
+  function updateLine(d: FunctionPlotDatum, secant: FunctionPlotDatumSecant) {
     if (!('x0' in secant)) {
       throw Error('secant must have the property `x0` defined')
     }
@@ -29,20 +29,20 @@ export default function secant (chart: Chart) {
     const x0 = secant.x0
     const x1 = typeof secant.x1 === 'number' ? secant.x1 : Infinity
     Object.assign(secant.scope, {
-      x0: x0,
-      x1: x1,
+      x0,
+      x1,
       y0: builtInEvaluator(d, 'fn', { x: x0 }),
       y1: builtInEvaluator(d, 'fn', { x: x1 })
     })
     computeSlope(secant.scope)
   }
 
-  function setFn (d: FunctionPlotDatum, secant: FunctionPlotDatumSecant) {
+  function setFn(d: FunctionPlotDatum, secant: FunctionPlotDatumSecant) {
     updateLine(d, secant)
     secant.fn = 'm * (x - x0) + y0'
   }
 
-  function setMouseListener (d: FunctionPlotDatum, secantObject: FunctionPlotDatumSecant) {
+  function setMouseListener(d: FunctionPlotDatum, secantObject: FunctionPlotDatumSecant) {
     const self = this
     if (secantObject.updateOnMouseMove && !secantObject.$$mouseListener) {
       secantObject.$$mouseListener = function ({ x }: any) {
@@ -54,12 +54,12 @@ export default function secant (chart: Chart) {
     }
   }
 
-  function computeLines (d: FunctionPlotDatum) {
+  function computeLines(d: FunctionPlotDatum) {
     const self = this
     const data = []
     d.secants = d.secants || []
     for (let i = 0; i < d.secants.length; i += 1) {
-      const secant = d.secants[i] = Object.assign({}, secantDefaults, d.secants[i])
+      const secant = (d.secants[i] = Object.assign({}, secantDefaults, d.secants[i]))
       // necessary to make the secant have the same color as d
       secant.index = d.index
       if (!secant.fn) {
@@ -71,25 +71,19 @@ export default function secant (chart: Chart) {
     return data
   }
 
-  const secant = function (selection: Selection<any, FunctionPlotDatum, any, any>) {
+  function secant(selection: Selection<any, FunctionPlotDatum, any, any>) {
     selection.each(function (d) {
       const el = d3Select(this)
       const data = computeLines.call(selection, d)
-      const innerSelection = el.selectAll('g.secant')
-        .data(data)
+      const innerSelection = el.selectAll('g.secant').data(data)
 
-      const innerSelectionEnter = innerSelection.enter()
-        .append('g')
-        .attr('class', 'secant')
+      const innerSelectionEnter = innerSelection.enter().append('g').attr('class', 'secant')
 
       // enter + update
-      innerSelection.merge(innerSelectionEnter)
-        .call(polyline(chart))
+      innerSelection.merge(innerSelectionEnter).call(polyline(chart))
 
       // change the opacity of the secants
-      innerSelection.merge(innerSelectionEnter)
-        .selectAll('path')
-        .attr('opacity', 0.5)
+      innerSelection.merge(innerSelectionEnter).selectAll('path').attr('opacity', 0.5)
 
       // exit
       innerSelection.exit().remove()

--- a/src/samplers/builtIn.ts
+++ b/src/samplers/builtIn.ts
@@ -3,7 +3,7 @@ import clamp from 'clamp'
 import utils from '../utils'
 import { builtIn as evaluate } from '../helpers/eval'
 
-import { Chart } from '../index'
+import { Chart } from '../chart'
 import { FunctionPlotDatum } from '../types'
 
 function checkAsymptote(
@@ -106,7 +106,7 @@ function split(chart: Chart, d: FunctionPlotDatum, data: number[][]) {
 }
 
 function linear(chart: Chart, d: FunctionPlotDatum, range: [number, number], n: number) {
-  const allX = utils.space(chart, range, n)
+  const allX = utils.space(chart.options.xAxis.type, range, n)
   const yDomain = chart.meta.yScale.domain()
   const yDomainMargin = yDomain[1] - yDomain[0]
   const yMin = yDomain[0] - yDomainMargin * 1e5
@@ -114,7 +114,7 @@ function linear(chart: Chart, d: FunctionPlotDatum, range: [number, number], n: 
   let data = []
   for (let i = 0; i < allX.length; i += 1) {
     const x = allX[i]
-    const y = evaluate(d, 'fn', { x: x })
+    const y = evaluate(d, 'fn', { x })
     if (utils.isValidNumber(x) && utils.isValidNumber(y)) {
       data.push([x, clamp(y, yMin, yMax)])
     }
@@ -127,7 +127,7 @@ function parametric(chart: Chart, d: FunctionPlotDatum, range: [number, number],
   // range is mapped to canvas coordinates from the input
   // for parametric plots the range will tell the start/end points of the `t` param
   const parametricRange = d.range || [0, 2 * Math.PI]
-  const tCoords = utils.space(chart, parametricRange, nSamples)
+  const tCoords = utils.space(chart.options.xAxis.type, parametricRange, nSamples)
   const samples = []
   for (let i = 0; i < tCoords.length; i += 1) {
     const t = tCoords[i]
@@ -142,7 +142,7 @@ function polar(chart: Chart, d: FunctionPlotDatum, range: [number, number], nSam
   // range is mapped to canvas coordinates from the input
   // for polar plots the range will tell the start/end points of the `theta` param
   const polarRange = d.range || [-Math.PI, Math.PI]
-  const thetaSamples = utils.space(chart, polarRange, nSamples)
+  const thetaSamples = utils.space(chart.options.xAxis.type, polarRange, nSamples)
   const samples = []
   for (let i = 0; i < thetaSamples.length; i += 1) {
     const theta = thetaSamples[i]

--- a/src/samplers/interval.ts
+++ b/src/samplers/interval.ts
@@ -1,24 +1,25 @@
 import intervalArithmeticEval, { Interval } from 'interval-arithmetic-eval'
-import { Chart } from '../chart'
-import { FunctionPlotDatum } from '../types'
 
 import { interval as evaluate } from '../helpers/eval'
 import utils from '../utils'
 
+import { FunctionPlotDatum } from '../types'
+import { SamplerParams, SamplerFn } from './types'
+
 // disable the use of typed arrays in interval-arithmetic to improve the performance
 ;(intervalArithmeticEval as any).policies.disableRounding()
 
-function interval1d(chart: Chart, d: FunctionPlotDatum, range: [number, number], nSamples: number) {
-  const xCoords = utils.space(chart.options.xAxis.type, range, nSamples)
-  const xScale = chart.meta.xScale
-  const yScale = chart.meta.yScale
+function interval1d(samplerParams: SamplerParams): Array<any> {
+  const xCoords = utils.space(samplerParams.xAxis, samplerParams.range, samplerParams.nSamples)
+  const xScale = samplerParams.xScale
+  const yScale = samplerParams.yScale
   const yMin = yScale.domain()[0]
   const yMax = yScale.domain()[1]
   const samples = []
   let i
   for (i = 0; i < xCoords.length - 1; i += 1) {
     const x = { lo: xCoords[i], hi: xCoords[i + 1] }
-    const y = evaluate(d, 'fn', { x })
+    const y = evaluate(samplerParams.d, 'fn', { x })
     if (!Interval.isEmpty(y) && !Interval.isWhole(y)) {
       samples.push([x, y])
     }
@@ -69,8 +70,8 @@ function smallRect(x: Interval, y: Interval) {
   return Interval.width(x) < rectEps
 }
 
-function quadTree(x: Interval, y: Interval, meta: FunctionPlotDatum) {
-  const sample = evaluate(meta, 'fn', { x, y })
+function quadTree(x: Interval, y: Interval, d: FunctionPlotDatum) {
+  const sample = evaluate(d, 'fn', { x, y })
   const fulfills = Interval.zeroIn(sample)
   if (!fulfills) {
     return this
@@ -86,36 +87,36 @@ function quadTree(x: Interval, y: Interval, meta: FunctionPlotDatum) {
   const north = { lo: midY, hi: y.hi }
   const south = { lo: y.lo, hi: midY }
 
-  quadTree.call(this, east, north, meta)
-  quadTree.call(this, east, south, meta)
-  quadTree.call(this, west, north, meta)
-  quadTree.call(this, west, south, meta)
+  quadTree.call(this, east, north, d)
+  quadTree.call(this, east, south, d)
+  quadTree.call(this, west, north, d)
+  quadTree.call(this, west, south, d)
 }
 
-function interval2d(chart: Chart, meta: FunctionPlotDatum) {
-  const xScale = chart.meta.xScale
-  const xDomain = chart.meta.xScale.domain()
-  const yDomain = chart.meta.yScale.domain()
+function interval2d(samplerParams: SamplerParams): Array<any> {
+  const xScale = samplerParams.xScale
+  const xDomain = samplerParams.xScale.domain()
+  const yDomain = samplerParams.yScale.domain()
   const x = { lo: xDomain[0], hi: xDomain[1] }
   const y = { lo: yDomain[0], hi: yDomain[1] }
   const samples: any = []
   // 1 px
   rectEps = xScale.invert(1) - xScale.invert(0)
-  quadTree.call(samples, x, y, meta)
+  quadTree.call(samples, x, y, samplerParams.d)
   samples.scaledDx = 1
   return [samples]
 }
 
-const sampler = function (chart: Chart, d: FunctionPlotDatum, range: [number, number], nSamples: number) {
+const sampler: SamplerFn = function sampler(samplerParams: SamplerParams): Array<any> {
   const fnTypes = {
     implicit: interval2d,
     linear: interval1d
   }
-  if (!Object.hasOwn(fnTypes, d.fnType)) {
-    throw Error(d.fnType + ' is not supported in the `interval` sampler')
+  if (!Object.hasOwn(fnTypes, samplerParams.d.fnType)) {
+    throw Error(samplerParams.d.fnType + ' is not supported in the `interval` sampler')
   }
   // @ts-ignore
-  return fnTypes[d.fnType].apply(null, arguments)
+  return fnTypes[samplerParams.d.fnType].apply(null, arguments)
 }
 
 export default sampler

--- a/src/samplers/interval.ts
+++ b/src/samplers/interval.ts
@@ -1,18 +1,15 @@
 import intervalArithmeticEval, { Interval } from 'interval-arithmetic-eval'
+import { Chart } from '../chart'
+import { FunctionPlotDatum } from '../types'
 
 import { interval as evaluate } from '../helpers/eval'
 import utils from '../utils'
-
-import { Chart } from '../index'
-import { FunctionPlotDatum } from '../types'
-
-// const Interval = (intervalArithmeticEval as any).Interval
 
 // disable the use of typed arrays in interval-arithmetic to improve the performance
 ;(intervalArithmeticEval as any).policies.disableRounding()
 
 function interval1d(chart: Chart, d: FunctionPlotDatum, range: [number, number], nSamples: number) {
-  const xCoords = utils.space(chart, range, nSamples)
+  const xCoords = utils.space(chart.options.xAxis.type, range, nSamples)
   const xScale = chart.meta.xScale
   const yScale = chart.meta.yScale
   const yMin = yScale.domain()[0]

--- a/src/samplers/types.ts
+++ b/src/samplers/types.ts
@@ -1,0 +1,13 @@
+import { FunctionPlotDatum, FunctionPlotScale, FunctionPlotOptionsAxis } from '../types'
+
+export type SamplerParams = {
+  d: FunctionPlotDatum
+  range: [number, number]
+  xScale: FunctionPlotScale
+  yScale: FunctionPlotScale
+  xAxis: FunctionPlotOptionsAxis
+  yAxis: FunctionPlotOptionsAxis
+  nSamples: number
+}
+
+export type SamplerFn = (samplerParams: SamplerParams) => Array<any>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,11 @@
+import { ScaleLinear, ScaleLogarithmic } from 'd3-scale'
+
 export interface Interval {
   lo: number
   hi: number
 }
+
+export type FunctionPlotScale = ScaleLinear<number, number> | ScaleLogarithmic<number, number>
 
 export interface FunctionPlotOptionsAxis {
   /**
@@ -304,12 +308,12 @@ export interface FunctionPlotOptions {
   /**
    * The x-axis domain, internally state used to preserve the x-domain across multiple calls to function plot
    */
-  xDomain?: number[]
+  xDomain?: [number, number]
 
   /**
    * The y-axis domain, internally state used to preserve the y-domain across multiple calls to function plot
    */
-  yDomain?: number[]
+  yDomain?: [number, number]
 
   /**
    * The tip configuration

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,5 @@
 import globals from './globals'
 
-import { Chart } from './index'
 import { FunctionPlotDatum } from './types'
 
 const utils = {
@@ -17,10 +16,10 @@ const utils = {
     return typeof v === 'number' && !isNaN(v)
   },
 
-  space: function (chart: Chart, range: [number, number], n: number) {
+  space: function (type: string, range: [number, number], n: number) {
     const lo = range[0]
     const hi = range[1]
-    if (chart.options.xAxis.type === 'log') {
+    if (type === 'log') {
       return this.logspace(Math.log10(lo), Math.log10(hi), n)
     }
     // default is linear

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import globals from './globals'
 
-import { FunctionPlotDatum } from './types'
+import { FunctionPlotDatum, FunctionPlotOptionsAxis } from './types'
 
 const utils = {
   linspace: function (lo: number, hi: number, n: number): number[] {
@@ -16,10 +16,10 @@ const utils = {
     return typeof v === 'number' && !isNaN(v)
   },
 
-  space: function (type: string, range: [number, number], n: number) {
+  space: function (axis: FunctionPlotOptionsAxis, range: [number, number], n: number) {
     const lo = range[0]
     const hi = range[1]
-    if (type === 'log') {
+    if (axis.type === 'log') {
       return this.logspace(Math.log10(lo), Math.log10(hi), n)
     }
     // default is linear


### PR DESCRIPTION
When I started the library I didn't care about maintainability so I sent a huge object with tons of public properties downstream, it makes it hard to make changes and refactors because I don't know what's getting used where.

I'm going to pay that debt by creating subsets of objects like `Chart` that will be sent downstream.

This doesn't introduce any breaking change as it's mostly a refactor.