### PR TITLE
Fix issue in computed data split, remove clamp dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   },
   "dependencies": {
     "built-in-math-eval": "^0.3.0",
-    "clamp": "^1.0.1",
     "d3-axis": "^3.0.0",
     "d3-color": "^3.1.0",
     "d3-format": "^3.1.0",

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -3,19 +3,14 @@ import interval from './samplers/interval'
 import builtIn from './samplers/builtIn'
 
 import { Chart } from './index'
-import { FunctionPlotDatum } from './types'
+import { FunctionPlotDatum, FunctionPlotScale } from './types'
 
 type SamplerTypeFn = typeof interval | typeof builtIn
 
 /**
- * Computes the endpoints x_lo, x_hi of the range
- * from which the sampler will take samples
- *
- * @param {Object} scale
- * @param {Object} d An item from `data`
- * @returns {Array}
+ * Computes the endpoints x_lo, x_hi of the range in d.range from which the sampler will take samples.
  */
-function computeEndpoints(scale: any, d: any): [number, number] {
+function computeEndpoints(scale: FunctionPlotScale, d: FunctionPlotDatum): [number, number] {
   const range = d.range || [-Infinity, Infinity]
   const start = Math.max(scale.domain()[0], range[0])
   const end = Math.min(scale.domain()[1], range[1])

--- a/src/external.d.ts
+++ b/src/external.d.ts
@@ -1,7 +1,3 @@
-declare module 'clamp' {
-  export default function clamp(lo: number, hi: number, n: number): number
-}
-
 declare module 'built-in-math-eval' {
   export default function eval(expr: string): any
 }

--- a/src/graph-types/polyline.ts
+++ b/src/graph-types/polyline.ts
@@ -1,6 +1,5 @@
 import { select as d3Select, Selection } from 'd3-selection'
 import { line as d3Line, area as d3Area, curveLinear as d3CurveLinear } from 'd3-shape'
-import clamp from 'clamp'
 
 import utils from '../utils'
 import evaluate from '../evaluate'
@@ -27,12 +26,12 @@ export default function polyline(chart: Chart) {
       yMax += diff * 1e6
       yMin -= diff * 1e6
       if (d.skipBoundsCheck) {
-        yMax = Infinity
-        yMin = -Infinity
+        yMax = utils.infinity()
+        yMin = -utils.infinity()
       }
 
       function y(d: number[]) {
-        return clamp(chart.meta.yScale(d[1]), yMin, yMax)
+        return utils.clamp(chart.meta.yScale(d[1]), yMin, yMax)
       }
 
       const line = d3Line()

--- a/src/graph-types/scatter.ts
+++ b/src/graph-types/scatter.ts
@@ -7,7 +7,7 @@ import evaluate from '../evaluate'
 import { Chart } from '../index'
 import { FunctionPlotDatum } from '../types'
 
-export default function scatter(chart: Chart) {
+export default function Scatter(chart: Chart) {
   const xScale = chart.meta.xScale
   const yScale = chart.meta.yScale
 
@@ -27,7 +27,7 @@ export default function scatter(chart: Chart) {
         }
       }
 
-      const innerSelection = d3Select(this).selectAll(':scope > circle').data(joined)
+      const innerSelection = d3Select(this).selectAll(':scope > circle.scatter').data(joined)
 
       const cls = `scatter scatter-${index}`
       const innerSelectionEnter = innerSelection.enter().append('circle').attr('class', cls)

--- a/src/helpers/derivative.ts
+++ b/src/helpers/derivative.ts
@@ -3,8 +3,9 @@ import { select as d3Select, Selection } from 'd3-selection'
 import { polyline } from '../graph-types/'
 import { builtIn as builtInEvaluator } from './eval'
 import datumDefaults from '../datum-defaults'
+import utils from '../utils'
 
-import { Chart } from "../index";
+import { Chart } from '../index'
 import { FunctionPlotDatum } from '../types'
 
 export default function derivative(chart: Chart) {
@@ -16,22 +17,22 @@ export default function derivative(chart: Chart) {
     graphType: 'polyline'
   })
 
-  function computeLine (d: FunctionPlotDatum) {
+  function computeLine(d: FunctionPlotDatum) {
     if (!d.derivative) {
       return []
     }
-    const x0 = typeof d.derivative.x0 === 'number' ? d.derivative.x0 : Infinity
+    const x0 = typeof d.derivative.x0 === 'number' ? d.derivative.x0 : utils.infinity()
     derivativeDatum.index = d.index
     derivativeDatum.scope = {
       m: builtInEvaluator(d.derivative, 'fn', { x: x0 }),
-      x0: x0,
+      x0,
       y0: builtInEvaluator(d, 'fn', { x: x0 })
     }
     derivativeDatum.fn = 'm * (x - x0) + y0'
     return [derivativeDatum]
   }
 
-  function checkAutoUpdate (d: FunctionPlotDatum) {
+  function checkAutoUpdate(d: FunctionPlotDatum) {
     const self = this
     if (!d.derivative) {
       return
@@ -57,22 +58,16 @@ export default function derivative(chart: Chart) {
       const el = d3Select(this)
       const data = computeLine.call(selection, d)
       checkAutoUpdate.call(selection, d)
-      const innerSelection = el.selectAll('g.derivative')
-        .data(data)
+      const innerSelection = el.selectAll('g.derivative').data(data)
 
-      const innerSelectionEnter = innerSelection.enter()
-        .append('g')
-        .attr('class', 'derivative')
+      const innerSelectionEnter = innerSelection.enter().append('g').attr('class', 'derivative')
 
       // enter + update
-      innerSelection.merge(innerSelectionEnter)
-        .call(polyline(chart))
+      innerSelection.merge(innerSelectionEnter).call(polyline(chart))
 
       // update
       // change the opacity of the line
-      innerSelection.merge(innerSelectionEnter)
-        .selectAll('path')
-        .attr('opacity', 0.5)
+      innerSelection.merge(innerSelectionEnter).selectAll('path').attr('opacity', 0.5)
 
       innerSelection.exit().remove()
     })

--- a/src/helpers/secant.ts
+++ b/src/helpers/secant.ts
@@ -3,6 +3,7 @@ import { select as d3Select, Selection } from 'd3-selection'
 import { builtIn as builtInEvaluator } from './eval'
 import datumDefaults from '../datum-defaults'
 import { polyline } from '../graph-types/'
+import utils from '../utils'
 
 import { Chart } from '../index'
 import { FunctionPlotDatumScope, FunctionPlotDatum, FunctionPlotDatumSecant } from '../types'
@@ -27,7 +28,7 @@ export default function secant(chart: Chart) {
     secant.scope = secant.scope || {}
 
     const x0 = secant.x0
-    const x1 = typeof secant.x1 === 'number' ? secant.x1 : Infinity
+    const x1 = typeof secant.x1 === 'number' ? secant.x1 : utils.infinity()
     Object.assign(secant.scope, {
       x0,
       x1,

--- a/src/samplers/builtIn.test.js
+++ b/src/samplers/builtIn.test.js
@@ -1,0 +1,165 @@
+import { scaleLinear as d3ScaleLinear } from 'd3-scale'
+import { expect } from '@jest/globals'
+
+import builtIn from './builtIn'
+
+const width = 200
+const height = 100
+const xDomain = [-5, 5]
+const yDomain = [-5, 5]
+const xScale = d3ScaleLinear().domain(xDomain).range([0, width])
+const yScale = d3ScaleLinear().domain(yDomain).range([height, 0])
+
+function toBeCloseTo(got, want, eps = 1e-3) {
+  if (!Array.isArray(got) || !Array.isArray(want)) {
+    throw new Error('Got and Want must be arrays')
+  }
+  if (Math.abs(got[0] - want[0]) > eps || Math.abs(got[1] - want[1]) > eps) {
+    return {
+      message: () =>
+        `expected ${this.utils.printReceived(got)} to be within range of ${this.utils.printReceived(want)}`,
+      pass: false
+    }
+  }
+  return { pass: true }
+}
+
+expect.extend({ toBeCloseTo })
+
+describe('builtIn sampler', () => {
+  describe('with linear sampler', () => {
+    it('should render 2 points for x', () => {
+      const nSamples = 2
+      // map the screen coordinates [0, width] to the domain [-5, 5]
+      const samplerParams = {
+        d: { fn: '1000000*x', fnType: 'linear' },
+        range: xDomain,
+        xScale,
+        yScale,
+        xAxis: { type: 'linear' },
+        nSamples
+      }
+      const data = builtIn(samplerParams)
+      expect(data instanceof Array).toEqual(true)
+      expect(data.length).toEqual(1) /* we expect 1 group of points (all connected) */
+      expect(data[0].length).toEqual(nSamples) /* the group should have 101 points */
+      expect(data[0][0]).toEqual([-5, -5000000])
+      expect(data[0][1]).toEqual([5, 5000000])
+    })
+
+    it('should render 101 points for x^2', () => {
+      const nSamples = 101
+      // map the screen coordinates [0, width] to the domain [-5, 5]
+      const samplerParams = {
+        d: { fn: 'x^2', fnType: 'linear' },
+        range: xDomain,
+        xScale,
+        yScale,
+        xAxis: { type: 'linear' },
+        nSamples
+      }
+      const data = builtIn(samplerParams)
+      expect(data instanceof Array).toEqual(true)
+      expect(data.length).toEqual(1) /* we expect 1 group of points (all connected) */
+      expect(data[0].length).toEqual(nSamples) /* the group should have 101 points */
+      expect(data[0][0]).toEqual([-5, 25]) /* f(-5) = [-5, 25] */
+      expect(data[0][50]).toEqual([0, 0]) /* f(0) = [0, 0] */
+      expect(data[0][100]).toEqual([5, 25]) /* f(5) = [5, 25] */
+    })
+
+    it('should render 2 groups for 1/x', () => {
+      const nSamples = 1000
+      // map the screen coordinates [0, width] to the domain [-5, 5]
+      const samplerParams = {
+        d: { fn: '1/x', fnType: 'linear' },
+        range: xDomain,
+        xScale,
+        yScale,
+        xAxis: { type: 'linear' },
+        nSamples
+      }
+      const data = builtIn(samplerParams)
+      expect(data instanceof Array).toEqual(true)
+      expect(data.length).toEqual(2) /* we expect 2 group of points (left of 0, right of 0) */
+      expect(data[0].length).toEqual(nSamples / 2) /* the 1st group should have 50 points */
+      expect(data[1].length).toEqual(nSamples / 2) /* the 2nd group should have 50 points */
+    })
+  })
+
+  describe('with parametric sampler', () => {
+    it('should render a circle of radius 1', () => {
+      const nSamples = 1001
+      const samplerParams = {
+        d: { x: 'cos(t)', y: 'sin(t)', fnType: 'parametric' },
+        range: xDomain,
+        xScale,
+        yScale,
+        xAxis: { type: 'linear' },
+        nSamples
+      }
+      const data = builtIn(samplerParams)
+      expect(data instanceof Array).toEqual(true)
+      expect(data.length).toEqual(1) /* we expect 2 group of points (left of 0, right of 0) */
+      expect(data[0].length).toEqual(nSamples) /* the 1st group should have 50 points */
+      expect(data[0][0]).toBeCloseTo([1, 0])
+      expect(data[0][250]).toBeCloseTo([0, 1])
+      expect(data[0][500]).toBeCloseTo([-1, 0])
+      expect(data[0][750]).toBeCloseTo([0, -1])
+      expect(data[0][1000]).toBeCloseTo([1, 0])
+    })
+  })
+
+  describe('with points sampler', () => {
+    it('should render a cube', () => {
+      const nSamples = 4
+      const samplerParams = {
+        d: {
+          points: [
+            [1, 1],
+            [2, 1],
+            [2, 2],
+            [1, 2]
+          ],
+          fnType: 'points'
+        },
+        range: xDomain,
+        xScale,
+        yScale,
+        xAxis: { type: 'linear' },
+        nSamples
+      }
+      const data = builtIn(samplerParams)
+      expect(data instanceof Array).toEqual(true)
+      expect(data.length).toEqual(1) /* we expect 1 group */
+      expect(data[0].length).toEqual(nSamples) /* to have 4 points */
+      expect(data[0][0]).toBeCloseTo([1, 1])
+      expect(data[0][1]).toBeCloseTo([2, 1])
+      expect(data[0][2]).toBeCloseTo([2, 2])
+      expect(data[0][3]).toBeCloseTo([1, 2])
+    })
+  })
+
+  describe('with vector sampler', () => {
+    it('should render a vector', () => {
+      const nSamples = 2
+      const samplerParams = {
+        d: {
+          vector: [2, 1],
+          offset: [1, 2],
+          fnType: 'vector'
+        },
+        range: xDomain,
+        xScale,
+        yScale,
+        xAxis: { type: 'linear' },
+        nSamples
+      }
+      const data = builtIn(samplerParams)
+      expect(data instanceof Array).toEqual(true)
+      expect(data.length).toEqual(1) /* we expect 1 group */
+      expect(data[0].length).toEqual(nSamples) /* to have 2 points */
+      expect(data[0][0]).toBeCloseTo([1, 2])
+      expect(data[0][1]).toBeCloseTo([3, 3])
+    })
+  })
+})

--- a/src/tip.ts
+++ b/src/tip.ts
@@ -1,6 +1,5 @@
 import { line as d3Line } from 'd3-shape'
 import { select as d3Select, Selection } from 'd3-selection'
-import clamp from 'clamp'
 
 import utils from './utils'
 import globals from './globals'
@@ -104,7 +103,6 @@ export default function mouseTip(config: FunctionPlotTip) {
     let x, y
 
     const selection = tipInnerJoin.merge(tipInnerEnter)
-    const inf = 1e8
     const meta = config.owner.meta
     const data = selection.datum().data
     const xScale = meta.xScale
@@ -124,7 +122,7 @@ export default function mouseTip(config: FunctionPlotTip) {
         continue
       }
 
-      const range = data[i].range || [-inf, inf]
+      const range = data[i].range || [-utils.infinity(), utils.infinity()]
       let candidateY
       if (x0 > range[0] - globals.TIP_X_EPS && x0 < range[1] + globals.TIP_X_EPS) {
         try {
@@ -151,9 +149,9 @@ export default function mouseTip(config: FunctionPlotTip) {
       tip.show()
       config.owner.emit('tip:update', { x, y, index: closestIndex })
       // @ts-ignore
-      const clampX = clamp(x, xScale.invert(-MARGIN), xScale.invert(width + MARGIN))
+      const clampX = utils.clamp(x, xScale.invert(-MARGIN), xScale.invert(width + MARGIN))
       // @ts-ignore
-      const clampY = clamp(y, yScale.invert(height + MARGIN), yScale.invert(-MARGIN))
+      const clampY = utils.clamp(y, yScale.invert(height + MARGIN), yScale.invert(-MARGIN))
       const color = utils.color(data[closestIndex], closestIndex)
       selection.style('color', 'red')
       selection.attr('transform', 'translate(' + xScale(clampX) + ',' + yScale(clampY) + ')')

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,9 +47,22 @@ const utils = {
     return 0
   },
 
+  clamp: function (v: number, vMin: number, vMax: number) {
+    if (v < vMin) return vMin
+    if (v > vMax) return vMax
+    return v
+  },
+
   color: function (data: FunctionPlotDatum, index: number): string {
     const indexModLenColor = index % globals.COLORS.length
     return data.color || globals.COLORS[indexModLenColor].hex()
+  },
+
+  /**
+   * Infinity is a value that is close to Infinity but not Infinity, it can fit in a JS number.
+   */
+  infinity: function (): number {
+    return 9007199254740991
   }
 }
 


### PR DESCRIPTION
The data wasn't split into groups as expected, sometimes there would be more groups than what's expected.