### PR TITLE
Feat: remove support for automatic usage of the mathjs sampler

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -187,7 +187,6 @@
 </div>
 
 <!-- includes -->
-<script src="//cdnjs.cloudflare.com/ajax/libs/mathjs/7.2.0/math.min.js"></script>
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
 <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.11.2.min.js"><\/script>')</script>
 <script src="js/plugins.js"></script>

--- a/site/js/site.js
+++ b/site/js/site.js
@@ -362,7 +362,7 @@ function onSiteDependenciesLoaded() {
    * Plotting roots can be a challenging problem, most plotters will actually
    * analyze expression of the type $x^{\tfrac{a}{b}}$, particularly they will
    * analyze the denominator of the exponent (to plot in the negative x-axis),
-   * interval-arithmetic and math.js come bundled with a useful `nthRoot`
+   * interval-arithmetic comes bundled with a useful `nthRoot`
    * function to solve these issues
    */
   functionPlot({
@@ -964,47 +964,6 @@ function onSiteDependenciesLoaded() {
         attr: {
           'text-anchor': 'end'
         }
-      }
-    ]
-  })
-
-  /**
-   * ### Advanced: sampler
-   *
-   * `function-plot` uses interval-arithmetic math by default, unfortunately some functions are
-   * not implemented yet because of the underlying complexity, for this reason you can always
-   * evaluate a function with <img style="width: 50px; height: 15px" src="img/mathjs_330x100.png"/>,
-   * to do so make sure that you include `math.js` before` function-plot`
-   *
-   * ```html
-   * <script src="//cdnjs.cloudflare.com/ajax/libs/mathjs/1.5.2/math.min.js"></script>
-   * ```
-   *
-   * And then set the following:
-   *
-   * - `sampler: 'builtIn'` the parser bundled with function-plot will be replaced with the one
-   * in math.js
-   * - `graphType: 'polyline'` or `graphType: 'scatter'`
-   */
-  functionPlot({
-    target: '#sampler-mathjs',
-    disableZoom: true,
-    data: [
-      {
-        fn: 'gamma(x)',
-        sampler: 'builtIn',
-        graphType: 'polyline'
-      }
-    ]
-  })
-  functionPlot({
-    target: '#sampler-tan-mathjs',
-    data: [
-      {
-        fn: 'tan(x)',
-        nSamples: 4000,
-        sampler: 'builtIn',
-        graphType: 'polyline'
       }
     ]
   })

--- a/site/partials/examples.html
+++ b/site/partials/examples.html
@@ -231,7 +231,7 @@ that holds the info of the function to render</p></div><div class="code"><pre><c
 <p>Plotting roots can be a challenging problem, most plotters will actually 
 analyze expression of the type $x^{\tfrac{a}{b}}$, particularly they will 
 analyze the denominator of the exponent (to plot in the negative x-axis), 
-interval-arithmetic and math.js come bundled with a useful <code>nthRoot</code> 
+interval-arithmetic comes bundled with a useful <code>nthRoot</code> 
 function to solve these issues</p></div><div class="code"><pre><code class="javascript">functionPlot({
   target: '#root-finding',
   data: [
@@ -691,40 +691,7 @@ functionPlot({
       }
     }
   ]
-})</code></pre></div></div><div class="col-md-6 center-block demos"><span class="graph" id="text"></span></div></div></div></div><div class="example"><div class="container"><div class="row"><div class="col-md-6"><div class="comment"><h3>Advanced: sampler</h3>
-<p><code>function-plot</code> uses interval-arithmetic math by default, unfortunately some functions are 
-not implemented yet because of the underlying complexity, for this reason you can always 
-evaluate a function with <img style="width: 50px; height: 15px" src="img/mathjs_330x100.png"/>, 
-to do so make sure that you include <code>math.js</code> before<code> function-plot</code></p>
-<pre><code class="lang-html">&lt;script src=&quot;//cdnjs.cloudflare.com/ajax/libs/mathjs/1.5.2/math.min.js&quot;&gt;&lt;/script&gt;
-</code></pre>
-<p>And then set the following:</p>
-<ul>
-<li><code>sampler: 'builtIn'</code> the parser bundled with function-plot will be replaced with the one 
-in math.js</li>
-<li><code>graphType: 'polyline'</code> or <code>graphType: 'scatter'</code></li>
-</ul></div><div class="code"><pre><code class="javascript">functionPlot({
-  target: '#sampler-mathjs',
-  disableZoom: true,
-  data: [
-    {
-      fn: 'gamma(x)',
-      sampler: 'builtIn',
-      graphType: 'polyline'
-    }
-  ]
-})
-functionPlot({
-  target: '#sampler-tan-mathjs',
-  data: [
-    {
-      fn: 'tan(x)',
-      nSamples: 4000,
-      sampler: 'builtIn',
-      graphType: 'polyline'
-    }
-  ]
-})</code></pre></div></div><div class="col-md-6 center-block demos"><span class="graph" id="sampler-mathjs"></span><span class="graph" id="sampler-tan-mathjs"></span></div></div></div></div><div class="example"><div class="container"><div class="row"><div class="col-md-6"><div class="comment"><h3>Advanced: property evaluation</h3>
+})</code></pre></div></div><div class="col-md-6 center-block demos"><span class="graph" id="text"></span></div></div></div></div><div class="example"><div class="container"><div class="row"><div class="col-md-6"><div class="comment"><h3>Advanced: property evaluation</h3>
 <p>All of the examples above used a string in the property to evaluate e.g.</p>
 <pre><code> // n
  functionPlot({

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { Chart, ChartMeta, ChartMetaMargin } from './chart.js'
 
 import globals, { registerGraphType } from './globals.mjs'
 import { polyline, interval, scatter, text } from './graph-types/index.js'
-import { interval as intervalEval, builtIn as builtInEval } from './samplers/eval.mjs'
+import { interval as intervalEval, builtIn as builtInEval, registerEvaluator } from './samplers/eval.mjs'
 
 // register common graphTypes on library load.
 registerGraphType('polyline', polyline)
@@ -53,6 +53,7 @@ functionPlot.withWebWorkers = withWebWorkers
 export * from './types.js'
 export { Chart, ChartMeta, ChartMetaMargin }
 export { registerGraphType, withWebWorkers }
+export { registerEvaluator }
 export { builtIn as EvalBuiltIn, interval as EvalInterval } from './samplers/eval.mjs'
 export {
   interval as GraphTypeInterval,

--- a/src/samplers/eval.mjs
+++ b/src/samplers/eval.mjs
@@ -1,83 +1,21 @@
 import builtInMathEval from 'built-in-math-eval'
 import intervalArithmeticEval from 'interval-arithmetic-eval'
 
-const samplers = {
-  interval: intervalArithmeticEval,
-  builtIn: builtInMathEval
-}
-
-// getMathJS returns checks if mathjs is loaded.
-function getMathJS() {
-  if (typeof global === 'object' && 'math' in global) {
-    // @ts-ignore
-    return global.math
-  }
-  if (typeof window === 'object' && 'math' in window) {
-    // @ts-ignore
-    return window.math
-  }
-  return null
-}
-
-const mathJS = getMathJS()
-if (mathJS) {
-  // override the built-in module with mathjs's compile
-  samplers.builtIn = mathJS.compile
-}
-
-function generateEvaluator(samplerName) {
-  function doCompile(expression) {
-    // compiles does the following
-    //
-    // when expression === string
-    //
-    //     gen = new require('math-codegen')
-    //     return gen.parse(expression).compile(Interval|BultInMath)
-    //
-    //     which is an object with the form
-    //
-    //     {
-    //       eval: function (scope) {
-    //         // math-codegen magic
-    //       }
-    //     }
-    //
-    // when expression === function
-    //
-    //    {
-    //      eval: expression
-    //    }
-    //
-    // otherwise throw an error
-    if (typeof expression === 'string') {
-      const compiled = samplers[samplerName](expression)
-      if (mathJS && samplerName === 'builtIn') {
-        // if mathjs is included use its evaluate method instead
-        return { eval: compiled.evaluate || compiled.eval }
-      }
-      return compiled
-    } else if (typeof expression === 'function') {
-      return { eval: expression }
-    } else {
-      throw Error('expression must be a string or a function')
-    }
-  }
-
-  function compileIfPossible(meta, property) {
-    // compile the function using interval arithmetic, cache the result
-    // so that multiple calls with the same argument don't trigger the
-    // kinda expensive compilation process
-    const expression = meta[property]
+/**
+ * @param expressionCompiler A function which when called must return an object
+ * with the form \{ eval: function \}
+ */
+function registerEvaluator(samplerName, expressionCompiler) {
+  function getCompiledExpression(meta, property) {
     const hiddenProperty = samplerName + '_Expression_' + property
     const hiddenCompiled = samplerName + '_Compiled_' + property
-    if (expression !== meta[hiddenProperty]) {
-      meta[hiddenProperty] = expression
-      meta[hiddenCompiled] = doCompile(expression)
+    if (meta[property] !== meta[hiddenProperty]) {
+      meta[hiddenProperty] = meta[property]
+      // compile the function once and cache the result so that multiple calls
+      // with the same argument don't trigger the expensive compilation process
+      meta[hiddenCompiled] = expressionCompiler(meta[property])
     }
-  }
-
-  function getCompiledExpression(meta, property) {
-    return meta[samplerName + '_Compiled_' + property]
+    return meta[hiddenCompiled]
   }
 
   /**
@@ -88,30 +26,50 @@ function generateEvaluator(samplerName) {
    * - Evaluates the resulting function with the merge of meta.scope and
    *   `variables`
    *
+   * @example
+   *
+   * meta: {
+   *   fn: 'x + 3',
+   *   scope: { y: 3 }
+   * }
+   * property: 'fn'
+   * variables:  { x: 3 }
+   *
    * @param meta
    * @param property
    * @param variables
    * @returns The builtIn evaluator returns a number, the interval evaluator an array
    */
   function evaluate(meta, property, variables) {
-    // e.g.
-    //
-    //  meta: {
-    //    fn: 'x + 3',
-    //    scope: { y: 3 }
-    //  }
-    //  property: 'fn'
-    //  variables:  { x: 3 }
-    //
-    compileIfPossible(meta, property)
-
-    return getCompiledExpression(meta, property).eval(Object.assign({}, meta.scope || {}, variables))
+    return getCompiledExpression(meta, property)
+      .eval(Object.assign({}, meta.scope || {}, variables))
   }
 
   return evaluate
 }
 
-const builtIn = generateEvaluator('builtIn')
-const interval = generateEvaluator('interval')
+function builtInExpressionCompiler(expression) {
+  if (typeof expression === 'string') {
+    return builtInMathEval(expression)
+  } else if (typeof expression === 'function') {
+    return { eval: expression }
+  } else {
+    throw Error('expression must be a string or a function')
+  }
+}
 
-export { builtIn, interval }
+const builtIn = registerEvaluator('builtIn', builtInExpressionCompiler)
+
+function intervalExpressionCompiler(expression) {
+  if (typeof expression === 'string') {
+    return intervalArithmeticEval(expression)
+  } else if (typeof expression === 'function') {
+    return { eval: expression }
+  } else {
+    throw Error('expression must be a string or a function')
+  }
+}
+
+const interval = registerEvaluator('interval', intervalExpressionCompiler)
+
+export { builtIn, interval, registerEvaluator }

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,7 +161,6 @@ export interface FunctionPlotDatum {
    * The sampler to take samples from `range`, available values are `interval|builtIn`
    *
    * - **NOTE: `builtIn` should only be used when `graphType` is `polyline|scatter`**
-   * - **NOTE: when math.js is included in the webpage it will be used instead of the bundled sampler**
    */
   sampler?: 'interval' | 'builtIn' | 'asyncInterval'
 


### PR DESCRIPTION
** Breaking Change **

Before this change if math.js was included in the webpage it would replace the builtIn sampler.

After this change any hardcoded reference to math.js were removed from the codebase, instead, users that want to use need to register an evaluator.

Pending work: use registered evaluators, right now it's still hardcoded that some graph types will use the builtIn sampler only.