### PR TITLE
Add the sticky positioning to center the origin axes

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,19 @@ export interface FunctionPlotOptionsAxis {
    * True to invert the direction of the axis
    */
   invert?: boolean
+
+  /**
+   * The position of the axis
+   *
+   * - `sticky`: The axis will be in the center.
+   * - `left`: The axis will be positioned on the left side. (Only for the yAxis)
+   * - `bottom`: The axis will be positioned at the bottom. (Only for the xAxis)
+   *
+   * Default values:
+   * - `xAxis`: `bottom`
+   * - `yAxis`: `left`
+   */
+  position?: 'sticky' | 'left' | 'bottom'
 }
 
 export interface FunctionPlotTip {


### PR DESCRIPTION
Added the option `position: sticky` to the axis, when set the axis will float in the viewport if the origin is visible.

Example:

```
      functionPlot({
        target: '#playground',
        title: 'quadratic with different axes position',
        width: 580,
        height: 400,
        xAxis: {
          position: 'sticky'
        },
        yAxis: {
          position: 'left'
        },
        data: [{
          fn: 'x^2'
        }]
      })
```

Ref #291 
Cherry pick of #295