### PR TITLE
Fix #342 polyline disappear when yAxis inverted

### DIFF
--- a/src/graph-types/polyline.ts
+++ b/src/graph-types/polyline.ts
@@ -18,6 +18,11 @@ export default function polyline(chart: Chart) {
       const yRange = chart.meta.yScale.range()
       let yMax = yRange[0]
       let yMin = yRange[1]
+
+      // Fix #342
+      // When yAxis is reversed, the yRange is inverted, i.e. yMin > yMax
+      if (yMin > yMax) [yMin, yMax] = [yMax, yMin]
+
       // workaround, clamp assuming that the bounds are finite but huge
       const diff = yMax - yMin
       yMax += diff * 1e6


### PR DESCRIPTION
Fix #342.

P.S. In `interval.ts` there's already a fix related to this issue, but `polyline.ts` didn't handle this. Weird.